### PR TITLE
Currently allows bbc.in.foo.com

### DIFF
--- a/webapp.rb
+++ b/webapp.rb
@@ -65,7 +65,7 @@ class BBCQRCode < Sinatra::Base
     end
 
     def is_bbc_in?(url)
-      url.match(/^https?:\/\/bbc\.in/)
+      url.match(/^https?:\/\/bbc\.in\//)
     end
 
     def to_qrcode_blob(code,size)


### PR DESCRIPTION
e.g. http://qrcode.prototyping.bbc.co.uk/qrcodes/400/aHR0cDovL2JiYy5pbi5nb2Vzd2hlcmUuY29tLw==
